### PR TITLE
Merge mappers

### DIFF
--- a/lib/CoreFilter/NativeCoreFilter.php
+++ b/lib/CoreFilter/NativeCoreFilter.php
@@ -43,7 +43,7 @@ class NativeCoreFilter extends CoreFilter
      *
      * @var string
      */
-    const FIELD_LANGUAGES = 'language_code_ms';
+    const FIELD_LANGUAGES = 'content_language_codes_ms';
 
     /**
      * Name of the Solr backend field holding language code of the indexed

--- a/lib/DocumentMapper/FieldMapper/Content/BlockDocumentsBaseContentFields.php
+++ b/lib/DocumentMapper/FieldMapper/Content/BlockDocumentsBaseContentFields.php
@@ -8,28 +8,23 @@
  *
  * @version //autogentag//
  */
-namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location;
+namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content;
 
-use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location as LocationMapper;
-use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content as ContentMapper;
+use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
-use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
 
 /**
- * Maps Content related fields to a Location document.
+ * Maps base Content related fields to block document (Content and Location).
  */
-class LocationDocumentContentFields extends LocationMapper
+class BlockDocumentsBaseContentFields extends ContentMapper
 {
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Handler
-     */
-    protected $contentHandler;
-
     /**
      * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
      */
@@ -51,38 +46,32 @@ class LocationDocumentContentFields extends LocationMapper
     protected $sectionHandler;
 
     /**
-     * @param \eZ\Publish\SPI\Persistence\Content\Handler $contentHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
      */
     public function __construct(
-        ContentHandler $contentHandler,
         LocationHandler $locationHandler,
         ContentTypeHandler $contentTypeHandler,
         ObjectStateHandler $objectStateHandler,
         SectionHandler $sectionHandler
     ) {
-        $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
         $this->contentTypeHandler = $contentTypeHandler;
         $this->objectStateHandler = $objectStateHandler;
         $this->sectionHandler = $sectionHandler;
     }
 
-    public function accept(Location $location)
+    public function accept(Content $content)
     {
         return true;
     }
 
-    public function mapFields(Location $location)
+    public function mapFields(Content $content)
     {
-        $contentInfo = $this->contentHandler->loadContentInfo($location->contentId);
-        $versionInfo = $this->contentHandler->loadVersionInfo(
-            $location->contentId,
-            $contentInfo->currentVersionNo
-        );
+        $versionInfo = $content->versionInfo;
+        $contentInfo = $content->versionInfo->contentInfo;
 
         // UserGroups and Users are Content, but permissions cascade is achieved through
         // Locations hierarchy. We index all ancestor Location Content ids of all

--- a/lib/DocumentMapper/FieldMapper/Content/ContentDocumentBaseFields.php
+++ b/lib/DocumentMapper/FieldMapper/Content/ContentDocumentBaseFields.php
@@ -86,102 +86,102 @@ class ContentDocumentBaseFields extends ContentMapper
 
         return [
             new Field(
-                'content',
-                $contentInfo->id,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
                 'document_type',
                 DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_CONTENT,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'type',
+                'content_id',
+                $contentInfo->id,
+                new FieldType\IdentifierField()
+            ),
+            new Field(
+                'content_type_id',
                 $contentInfo->contentTypeId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'version_no',
+                'content_version_no',
                 $versionInfo->versionNo,
                 new FieldType\IntegerField()
             ),
             new Field(
-                'status',
+                'content_version_status',
                 $versionInfo->status,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'name',
+                'content_name',
                 $contentInfo->name,
                 new FieldType\StringField()
             ),
             new Field(
-                'creator',
+                'content_version_creator_user_id',
                 $versionInfo->creatorId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'owner',
+                'content_owner_user_id',
                 $contentInfo->ownerId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'section',
+                'content_section_id',
                 $contentInfo->sectionId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'remote_id',
+                'content_remote_id',
                 $contentInfo->remoteId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'modified',
+                'content_modification_date',
                 $contentInfo->modificationDate,
                 new FieldType\DateField()
             ),
             new Field(
-                'published',
+                'content_publication_date',
                 $contentInfo->publicationDate,
                 new FieldType\DateField()
             ),
             new Field(
-                'language_code',
+                'content_language_codes',
                 array_keys($versionInfo->names),
                 new FieldType\MultipleStringField()
             ),
             new Field(
-                'main_language_code',
+                'content_main_language_code',
                 $contentInfo->mainLanguageCode,
                 new FieldType\StringField()
             ),
             new Field(
-                'always_available',
+                'content_always_available',
                 $contentInfo->alwaysAvailable,
                 new FieldType\BooleanField()
             ),
             new Field(
-                'owner_user_group',
+                'content_owner_user_group_ids',
                 $ancestorLocationsContentIds,
                 new FieldType\MultipleIdentifierField()
             ),
             new Field(
-                'section_identifier',
+                'content_section_identifier',
                 $section->identifier,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'section_name',
+                'content_section_name',
                 $section->name,
                 new FieldType\StringField()
             ),
             new Field(
-                'group',
+                'content_type_group_ids',
                 $this->contentTypeHandler->load($contentInfo->contentTypeId)->groupIds,
                 new FieldType\MultipleIdentifierField()
             ),
             new Field(
-                'object_state',
+                'content_object_state_ids',
                 $this->getObjectStateIds($contentInfo->id),
                 new FieldType\MultipleIdentifierField()
             ),

--- a/lib/DocumentMapper/FieldMapper/Content/ContentDocumentBaseFields.php
+++ b/lib/DocumentMapper/FieldMapper/Content/ContentDocumentBaseFields.php
@@ -12,10 +12,6 @@ namespace EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Conten
 
 use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content as ContentMapper;
 use EzSystems\EzPlatformSolrSearchEngine\DocumentMapper;
-use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
-use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\FieldType;
@@ -25,44 +21,6 @@ use eZ\Publish\SPI\Search\FieldType;
  */
 class ContentDocumentBaseFields extends ContentMapper
 {
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
-     */
-    protected $locationHandler;
-
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
-
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
-     */
-    protected $objectStateHandler;
-
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Content\Section\Handler
-     */
-    protected $sectionHandler;
-
-    /**
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler $objectStateHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Section\Handler $sectionHandler
-     */
-    public function __construct(
-        LocationHandler $locationHandler,
-        ContentTypeHandler $contentTypeHandler,
-        ObjectStateHandler $objectStateHandler,
-        SectionHandler $sectionHandler
-    ) {
-        $this->locationHandler = $locationHandler;
-        $this->contentTypeHandler = $contentTypeHandler;
-        $this->objectStateHandler = $objectStateHandler;
-        $this->sectionHandler = $sectionHandler;
-    }
-
     public function accept(Content $content)
     {
         return true;
@@ -70,177 +28,12 @@ class ContentDocumentBaseFields extends ContentMapper
 
     public function mapFields(Content $content)
     {
-        $versionInfo = $content->versionInfo;
-        $contentInfo = $content->versionInfo->contentInfo;
-
-        // UserGroups and Users are Content, but permissions cascade is achieved through
-        // Locations hierarchy. We index all ancestor Location Content ids of all
-        // Locations of an owner.
-        $ancestorLocationsContentIds = $this->getAncestorLocationsContentIds(
-            $contentInfo->ownerId
-        );
-        // Add owner user id as it can also be considered as user group.
-        $ancestorLocationsContentIds[] = $contentInfo->ownerId;
-
-        $section = $this->sectionHandler->load($contentInfo->sectionId);
-
         return [
             new Field(
                 'document_type',
                 DocumentMapper::DOCUMENT_TYPE_IDENTIFIER_CONTENT,
                 new FieldType\IdentifierField()
             ),
-            new Field(
-                'content_id',
-                $contentInfo->id,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_type_id',
-                $contentInfo->contentTypeId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_version_no',
-                $versionInfo->versionNo,
-                new FieldType\IntegerField()
-            ),
-            new Field(
-                'content_version_status',
-                $versionInfo->status,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_name',
-                $contentInfo->name,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'content_version_creator_user_id',
-                $versionInfo->creatorId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_owner_user_id',
-                $contentInfo->ownerId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_section_id',
-                $contentInfo->sectionId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_remote_id',
-                $contentInfo->remoteId,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_modification_date',
-                $contentInfo->modificationDate,
-                new FieldType\DateField()
-            ),
-            new Field(
-                'content_publication_date',
-                $contentInfo->publicationDate,
-                new FieldType\DateField()
-            ),
-            new Field(
-                'content_language_codes',
-                array_keys($versionInfo->names),
-                new FieldType\MultipleStringField()
-            ),
-            new Field(
-                'content_main_language_code',
-                $contentInfo->mainLanguageCode,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'content_always_available',
-                $contentInfo->alwaysAvailable,
-                new FieldType\BooleanField()
-            ),
-            new Field(
-                'content_owner_user_group_ids',
-                $ancestorLocationsContentIds,
-                new FieldType\MultipleIdentifierField()
-            ),
-            new Field(
-                'content_section_identifier',
-                $section->identifier,
-                new FieldType\IdentifierField()
-            ),
-            new Field(
-                'content_section_name',
-                $section->name,
-                new FieldType\StringField()
-            ),
-            new Field(
-                'content_type_group_ids',
-                $this->contentTypeHandler->load($contentInfo->contentTypeId)->groupIds,
-                new FieldType\MultipleIdentifierField()
-            ),
-            new Field(
-                'content_object_state_ids',
-                $this->getObjectStateIds($contentInfo->id),
-                new FieldType\MultipleIdentifierField()
-            ),
         ];
-    }
-
-    /**
-     * Returns an array of object state ids of a Content with given $contentId.
-     *
-     * @param int|string $contentId
-     *
-     * @return array
-     */
-    protected function getObjectStateIds($contentId)
-    {
-        $objectStateIds = array();
-
-        foreach ($this->objectStateHandler->loadAllGroups() as $objectStateGroup) {
-            $objectStateIds[] = $this->objectStateHandler->getContentState(
-                $contentId,
-                $objectStateGroup->id
-            )->id;
-        }
-
-        return $objectStateIds;
-    }
-
-    /**
-     * Returns Content ids of all ancestor Locations of all Locations
-     * of a Content with given $contentId.
-     *
-     * Used to determine user groups of a user with $contentId.
-     *
-     * @param int|string $contentId
-     *
-     * @return array
-     */
-    protected function getAncestorLocationsContentIds($contentId)
-    {
-        $locations = $this->locationHandler->loadLocationsByContent($contentId);
-        $ancestorLocationContentIds = array();
-        $ancestorLocationIds = array();
-
-        foreach ($locations as $location) {
-            $locationIds = explode('/', trim($location->pathString, '/'));
-            // Remove Location of Content with $contentId
-            array_pop($locationIds);
-            // Remove Root Location id (id==1 in legacy DB)
-            array_shift($locationIds);
-
-            $ancestorLocationIds = array_merge($ancestorLocationIds, $locationIds);
-        }
-
-        foreach (array_unique($ancestorLocationIds) as $locationId) {
-            $location = $this->locationHandler->load($locationId);
-
-            $ancestorLocationContentIds[$location->contentId] = true;
-        }
-
-        return array_keys($ancestorLocationContentIds);
     }
 }

--- a/lib/DocumentMapper/FieldMapper/Location/LocationDocumentContentFields.php
+++ b/lib/DocumentMapper/FieldMapper/Location/LocationDocumentContentFields.php
@@ -102,7 +102,7 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'content_type',
+                'content_type_id',
                 $contentInfo->contentTypeId,
                 new FieldType\IdentifierField()
             ),
@@ -112,7 +112,7 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\IntegerField()
             ),
             new Field(
-                'content_status',
+                'content_version_status',
                 $versionInfo->status,
                 new FieldType\IdentifierField()
             ),
@@ -122,17 +122,17 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\StringField()
             ),
             new Field(
-                'content_creator',
+                'content_version_creator_user_id',
                 $versionInfo->creatorId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'content_owner',
+                'content_owner_user_id',
                 $contentInfo->ownerId,
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'content_section',
+                'content_section_id',
                 $contentInfo->sectionId,
                 new FieldType\IdentifierField()
             ),
@@ -142,22 +142,22 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\IdentifierField()
             ),
             new Field(
-                'content_modified',
+                'content_modification_date',
                 $contentInfo->modificationDate,
                 new FieldType\DateField()
             ),
             new Field(
-                'content_published',
+                'content_publication_date',
                 $contentInfo->publicationDate,
                 new FieldType\DateField()
             ),
             new Field(
-                'language_code',
+                'content_language_codes',
                 array_keys($versionInfo->names),
                 new FieldType\MultipleStringField()
             ),
             new Field(
-                'main_language_code',
+                'content_main_language_code',
                 $contentInfo->mainLanguageCode,
                 new FieldType\StringField()
             ),
@@ -167,7 +167,7 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\BooleanField()
             ),
             new Field(
-                'content_owner_user_group',
+                'content_owner_user_group_ids',
                 $ancestorLocationsContentIds,
                 new FieldType\MultipleIdentifierField()
             ),
@@ -182,12 +182,12 @@ class LocationDocumentContentFields extends LocationMapper
                 new FieldType\StringField()
             ),
             new Field(
-                'content_group',
+                'content_type_group_ids',
                 $this->contentTypeHandler->load($contentInfo->contentTypeId)->groupIds,
                 new FieldType\MultipleIdentifierField()
             ),
             new Field(
-                'content_object_state',
+                'content_object_state_ids',
                 $this->getObjectStateIds($contentInfo->id),
                 new FieldType\MultipleIdentifierField()
             ),

--- a/lib/Query/Content/CriterionVisitor/ContentIdIn.php
+++ b/lib/Query/Content/CriterionVisitor/ContentIdIn.php
@@ -49,7 +49,7 @@ class ContentIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'content_id:"' . $value . '"';
+                        return 'content_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/lib/Query/Content/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -49,7 +49,7 @@ class ContentTypeGroupIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'group_mid:"' . $value . '"';
+                        return 'content_type_group_ids_mid:"' . $value . '"';
                     },
                     (array)$criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/ContentTypeIdIn.php
+++ b/lib/Query/Content/CriterionVisitor/ContentTypeIdIn.php
@@ -49,7 +49,7 @@ class ContentTypeIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'type_id:"' . $value . '"';
+                        return 'content_type_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/lib/Query/Content/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -71,7 +71,7 @@ class ContentTypeIdentifierIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) use ($contentTypeHandler) {
-                        return 'type_id:"' . $contentTypeHandler->loadByIdentifier($value)->id . '"';
+                        return 'content_type_id_id:"' . $contentTypeHandler->loadByIdentifier($value)->id . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/lib/Query/Content/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -58,6 +58,6 @@ class ModifiedBetween extends DateMetadata
             $start = null;
         }
 
-        return 'modified_dt:' . $this->getRange($criterion->operator, $start, $end);
+        return 'content_modification_date_dt:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Query/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/lib/Query/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -48,7 +48,7 @@ class ModifiedIn extends DateMetadata
     {
         $values = array();
         foreach ($criterion->value as $value) {
-            $values[] = 'modified_dt:"' . $this->getSolrTime($value) . '"';
+            $values[] = 'content_modification_date_dt:"' . $this->getSolrTime($value) . '"';
         }
 
         return '(' . implode(' OR ', $values) . ')';

--- a/lib/Query/Content/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/lib/Query/Content/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -58,6 +58,6 @@ class PublishedBetween extends DateMetadata
             $start = null;
         }
 
-        return 'published_dt:' . $this->getRange($criterion->operator, $start, $end);
+        return 'content_publication_date_dt:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Query/Content/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/lib/Query/Content/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -51,7 +51,7 @@ class PublishedIn extends DateMetadata
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'published_dt:"' . $this->getSolrTime($value) . '"';
+                        return 'content_publication_date_dt:"' . $this->getSolrTime($value) . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/LanguageCodeIn.php
+++ b/lib/Query/Content/CriterionVisitor/LanguageCodeIn.php
@@ -46,14 +46,14 @@ class LanguageCodeIn extends CriterionVisitor
     {
         $languageCodeExpressions = array_map(
             function ($value) {
-                return 'language_code_ms:"' . $value . '"';
+                return 'content_language_codes_ms:"' . $value . '"';
             },
             $criterion->value
         );
 
         /** @var Criterion\LanguageCode $criterion */
         if ($criterion->matchAlwaysAvailable) {
-            $languageCodeExpressions[] = 'always_available_b:true';
+            $languageCodeExpressions[] = 'content_always_available_b:true';
         }
 
         return '(' . implode(' OR ', $languageCodeExpressions) . ')';

--- a/lib/Query/Content/CriterionVisitor/ObjectStateIdIn.php
+++ b/lib/Query/Content/CriterionVisitor/ObjectStateIdIn.php
@@ -49,7 +49,7 @@ class ObjectStateIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'object_state_mid:"' . $value . '"';
+                        return 'content_object_state_ids_mid:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/RemoteIdIn.php
+++ b/lib/Query/Content/CriterionVisitor/RemoteIdIn.php
@@ -49,7 +49,7 @@ class RemoteIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'remote_id_id:"' . $value . '"';
+                        return 'content_remote_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/SectionIn.php
+++ b/lib/Query/Content/CriterionVisitor/SectionIn.php
@@ -49,7 +49,7 @@ class SectionIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'section_id:"' . $value . '"';
+                        return 'content_section_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Content/CriterionVisitor/UserMetadataIn.php
+++ b/lib/Query/Content/CriterionVisitor/UserMetadataIn.php
@@ -47,13 +47,13 @@ class UserMetadataIn extends CriterionVisitor
     {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:
-                $solrField = 'creator_id';
+                $solrField = 'content_version_creator_user_id_id';
                 break;
             case Criterion\UserMetadata::OWNER:
-                $solrField = 'owner_id';
+                $solrField = 'content_owner_user_id_id';
                 break;
             case Criterion\UserMetadata::GROUP:
-                $solrField = 'owner_user_group_mid';
+                $solrField = 'content_owner_user_group_ids_mid';
                 break;
 
             default:

--- a/lib/Query/Content/FacetBuilderVisitor/ContentType.php
+++ b/lib/Query/Content/FacetBuilderVisitor/ContentType.php
@@ -20,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 class ContentType extends FacetBuilderVisitor
 {
     /**
-     * CHeck if visitor is applicable to current facet result.
+     * Check if visitor is applicable to current facet result.
      *
      * @param string $field
      *
@@ -28,7 +28,7 @@ class ContentType extends FacetBuilderVisitor
      */
     public function canMap($field)
     {
-        return $field === 'type_id';
+        return $field === 'content_type_id_id';
     }
 
     /**
@@ -71,9 +71,9 @@ class ContentType extends FacetBuilderVisitor
     public function visit(FacetBuilder $facetBuilder)
     {
         return array(
-            'facet.field' => 'type_id',
-            'f.type_id.facet.limit' => $facetBuilder->limit,
-            'f.type_id.facet.mincount' => $facetBuilder->minCount,
+            'facet.field' => 'content_type_id_id',
+            'f.content_type_id_id.facet.limit' => $facetBuilder->limit,
+            'f.content_type_id_id.facet.mincount' => $facetBuilder->minCount,
         );
     }
 }

--- a/lib/Query/Content/FacetBuilderVisitor/Section.php
+++ b/lib/Query/Content/FacetBuilderVisitor/Section.php
@@ -20,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 class Section extends FacetBuilderVisitor
 {
     /**
-     * CHeck if visitor is applicable to current facet result.
+     * Check if visitor is applicable to current facet result.
      *
      * @param string $field
      *
@@ -28,7 +28,7 @@ class Section extends FacetBuilderVisitor
      */
     public function canMap($field)
     {
-        return $field === 'section_id';
+        return $field === 'content_section_id_id';
     }
 
     /**
@@ -71,9 +71,9 @@ class Section extends FacetBuilderVisitor
     public function visit(FacetBuilder $facetBuilder)
     {
         return array(
-            'facet.field' => 'section_id',
-            'f.section_id.facet.limit' => $facetBuilder->limit,
-            'f.section_id.facet.mincount' => $facetBuilder->minCount,
+            'facet.field' => 'content_section_id_id',
+            'f.content_section_id_id.facet.limit' => $facetBuilder->limit,
+            'f.content_section_id_id.facet.mincount' => $facetBuilder->minCount,
         );
     }
 }

--- a/lib/Query/Content/FacetBuilderVisitor/User.php
+++ b/lib/Query/Content/FacetBuilderVisitor/User.php
@@ -20,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 class User extends FacetBuilderVisitor
 {
     /**
-     * CHeck if visitor is applicable to current facet result.
+     * Check if visitor is applicable to current facet result.
      *
      * @param string $field
      *
@@ -28,7 +28,7 @@ class User extends FacetBuilderVisitor
      */
     public function canMap($field)
     {
-        return $field === 'creator_id';
+        return $field === 'content_version_creator_user_id_id';
     }
 
     /**
@@ -71,9 +71,9 @@ class User extends FacetBuilderVisitor
     public function visit(FacetBuilder $facetBuilder)
     {
         return array(
-            'facet.field' => 'creator_id',
-            'f.creator_id.facet.limit' => $facetBuilder->limit,
-            'f.creator_id.facet.mincount' => $facetBuilder->minCount,
+            'facet.field' => 'content_version_creator_user_id_id',
+            'f.content_version_creator_user_id_id.facet.limit' => $facetBuilder->limit,
+            'f.content_version_creator_user_id_id.facet.mincount' => $facetBuilder->minCount,
         );
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/ContentId.php
+++ b/lib/Query/Content/SortClauseVisitor/ContentId.php
@@ -39,6 +39,6 @@ class ContentId extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'content_id' . $this->getDirection($sortClause);
+        return 'content_id_id' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/ContentName.php
+++ b/lib/Query/Content/SortClauseVisitor/ContentName.php
@@ -39,6 +39,6 @@ class ContentName extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'name_s' . $this->getDirection($sortClause);
+        return 'content_name_s' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/DateModified.php
+++ b/lib/Query/Content/SortClauseVisitor/DateModified.php
@@ -39,6 +39,6 @@ class DateModified extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'modified_dt' . $this->getDirection($sortClause);
+        return 'content_modification_date_dt' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/DatePublished.php
+++ b/lib/Query/Content/SortClauseVisitor/DatePublished.php
@@ -39,6 +39,6 @@ class DatePublished extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'published_dt' . $this->getDirection($sortClause);
+        return 'content_publication_date_dt' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/SectionIdentifier.php
+++ b/lib/Query/Content/SortClauseVisitor/SectionIdentifier.php
@@ -39,6 +39,6 @@ class SectionIdentifier extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'section_identifier_id' . $this->getDirection($sortClause);
+        return 'content_section_identifier_id' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Content/SortClauseVisitor/SectionName.php
+++ b/lib/Query/Content/SortClauseVisitor/SectionName.php
@@ -39,6 +39,6 @@ class SectionName extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'section_name_s' . $this->getDirection($sortClause);
+        return 'content_section_name_s' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Location/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/lib/Query/Location/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -51,7 +51,7 @@ class ContentTypeGroupIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'content_group_mid:"' . $value . '"';
+                        return 'content_type_group_ids_mid:"' . $value . '"';
                     },
                     // TODO this should have been casted by criterion???
                     (array)$criterion->value

--- a/lib/Query/Location/CriterionVisitor/ContentTypeIdIn.php
+++ b/lib/Query/Location/CriterionVisitor/ContentTypeIdIn.php
@@ -51,7 +51,7 @@ class ContentTypeIdIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'content_type_id:"' . $value . '"';
+                        return 'content_type_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Location/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/lib/Query/Location/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -71,7 +71,7 @@ class ContentTypeIdentifierIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) use ($contentTypeHandler) {
-                        return 'content_type_id:"' . $contentTypeHandler->loadByIdentifier($value)->id . '"';
+                        return 'content_type_id_id:"' . $contentTypeHandler->loadByIdentifier($value)->id . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Location/CriterionVisitor/DateMetadata/ModifiedBetween.php
+++ b/lib/Query/Location/CriterionVisitor/DateMetadata/ModifiedBetween.php
@@ -58,6 +58,6 @@ class ModifiedBetween extends DateMetadata
             $start = null;
         }
 
-        return 'content_modified_dt:' . $this->getRange($criterion->operator, $start, $end);
+        return 'content_modification_date_dt:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Query/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/lib/Query/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -50,7 +50,7 @@ class ModifiedIn extends DateMetadata
     {
         $values = array();
         foreach ($criterion->value as $value) {
-            $values[] = 'content_modified_dt:"' . $this->getSolrTime($value) . '"';
+            $values[] = 'content_modification_date_dt:"' . $this->getSolrTime($value) . '"';
         }
 
         return '(' . implode(' OR ', $values) . ')';

--- a/lib/Query/Location/CriterionVisitor/DateMetadata/PublishedBetween.php
+++ b/lib/Query/Location/CriterionVisitor/DateMetadata/PublishedBetween.php
@@ -60,6 +60,6 @@ class PublishedBetween extends DateMetadata
             $start = null;
         }
 
-        return 'content_published_dt:' . $this->getRange($criterion->operator, $start, $end);
+        return 'content_publication_date_dt:' . $this->getRange($criterion->operator, $start, $end);
     }
 }

--- a/lib/Query/Location/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/lib/Query/Location/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -52,7 +52,7 @@ class PublishedIn extends DateMetadata
             ' OR ',
             array_map(
                 function ($value) {
-                    return 'content_published_dt:"' . $this->getSolrTime($value) . '"';
+                    return 'content_publication_date_dt:"' . $this->getSolrTime($value) . '"';
                 },
                 $criterion->value
             )

--- a/lib/Query/Location/CriterionVisitor/LanguageCodeIn.php
+++ b/lib/Query/Location/CriterionVisitor/LanguageCodeIn.php
@@ -46,7 +46,7 @@ class LanguageCodeIn extends CriterionVisitor
     {
         $languageCodeExpressions = array_map(
             function ($value) {
-                return 'language_code_ms:"' . $value . '"';
+                return 'content_language_codes_ms:"' . $value . '"';
             },
             $criterion->value
         );

--- a/lib/Query/Location/CriterionVisitor/ObjectStateIdIn.php
+++ b/lib/Query/Location/CriterionVisitor/ObjectStateIdIn.php
@@ -52,7 +52,7 @@ class ObjectStateIdIn extends CriterionVisitor
                 array_map(
                     function ($value) {
                         // TODO this should not be multiple???
-                        return 'content_object_state_mid:"' . $value . '"';
+                        return 'content_object_state_ids_mid:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Location/CriterionVisitor/SectionIn.php
+++ b/lib/Query/Location/CriterionVisitor/SectionIn.php
@@ -51,7 +51,7 @@ class SectionIn extends CriterionVisitor
                 ' OR ',
                 array_map(
                     function ($value) {
-                        return 'content_section_id:"' . $value . '"';
+                        return 'content_section_id_id:"' . $value . '"';
                     },
                     $criterion->value
                 )

--- a/lib/Query/Location/CriterionVisitor/UserMetadataIn.php
+++ b/lib/Query/Location/CriterionVisitor/UserMetadataIn.php
@@ -49,13 +49,13 @@ class UserMetadataIn extends CriterionVisitor
     {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:
-                $solrField = 'content_creator_id';
+                $solrField = 'content_version_creator_user_id_id';
                 break;
             case Criterion\UserMetadata::OWNER:
-                $solrField = 'content_owner_id';
+                $solrField = 'content_owner_user_id_id';
                 break;
             case Criterion\UserMetadata::GROUP:
-                $solrField = 'content_owner_user_group_mid';
+                $solrField = 'content_owner_user_group_ids_mid';
                 break;
 
             default:

--- a/lib/Query/Location/SortClauseVisitor/DateModified.php
+++ b/lib/Query/Location/SortClauseVisitor/DateModified.php
@@ -39,6 +39,6 @@ class DateModified extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'content_modified_dt' . $this->getDirection($sortClause);
+        return 'content_modification_date_dt' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Query/Location/SortClauseVisitor/DatePublished.php
+++ b/lib/Query/Location/SortClauseVisitor/DatePublished.php
@@ -39,6 +39,6 @@ class DatePublished extends SortClauseVisitor
      */
     public function visit(SortClause $sortClause)
     {
-        return 'content_published_dt' . $this->getDirection($sortClause);
+        return 'content_publication_date_dt' . $this->getDirection($sortClause);
     }
 }

--- a/lib/Resources/config/container/solr/document_field_mappers.yml
+++ b/lib/Resources/config/container/solr/document_field_mappers.yml
@@ -1,13 +1,23 @@
 parameters:
+    ezpublish.search.solr.document_field_mapper.block.block_documents_base_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content\BlockDocumentsBaseContentFields
     ezpublish.search.solr.document_field_mapper.block_translation.block_documents_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation\BlockDocumentsContentFields
     ezpublish.search.solr.document_field_mapper.block_translation.block_documents_meta_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation\BlockDocumentsMetaFields
     ezpublish.search.solr.document_field_mapper.content.content_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content\ContentDocumentBaseFields
     ezpublish.search.solr.document_field_mapper.content.content_document_location_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Content\ContentDocumentLocationFields
     ezpublish.search.solr.document_field_mapper.content_translation.content_document_fulltext_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\ContentTranslation\ContentDocumentFulltextFields
     ezpublish.search.solr.document_field_mapper.location.location_document_base_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location\LocationDocumentBaseFields
-    ezpublish.search.solr.document_field_mapper.location.location_document_content_fields.class: EzSystems\EzPlatformSolrSearchEngine\DocumentMapper\FieldMapper\Location\LocationDocumentContentFields
 
 services:
+    ezpublish.search.solr.document_field_mapper.block.block_documents_base_content_fields:
+        class: '%ezpublish.search.solr.document_field_mapper.block.block_documents_base_content_fields.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.location_handler'
+            - '@ezpublish.spi.persistence.content_type_handler'
+            - '@ezpublish.spi.persistence.object_state_handler'
+            - '@ezpublish.spi.persistence.section_handler'
+        tags:
+            - {name: ezpublish.search.solr.document_field_mapper.block}
+
     ezpublish.search.solr.document_field_mapper.block_translation.block_documents_content_fields:
         class: '%ezpublish.search.solr.document_field_mapper.block_translation.block_documents_content_fields.class%'
         arguments:
@@ -24,11 +34,6 @@ services:
 
     ezpublish.search.solr.document_field_mapper.content.content_document_base_fields:
         class: '%ezpublish.search.solr.document_field_mapper.content.content_document_base_fields.class%'
-        arguments:
-            - '@ezpublish.spi.persistence.location_handler'
-            - '@ezpublish.spi.persistence.content_type_handler'
-            - '@ezpublish.spi.persistence.object_state_handler'
-            - '@ezpublish.spi.persistence.section_handler'
         tags:
             - {name: ezpublish.search.solr.document_field_mapper.content}
 
@@ -52,16 +57,5 @@ services:
         class: '%ezpublish.search.solr.document_field_mapper.location.location_document_base_fields.class%'
         arguments:
             - '@ezpublish.spi.persistence.content_handler'
-        tags:
-            - {name: ezpublish.search.solr.document_field_mapper.location}
-
-    ezpublish.search.solr.document_field_mapper.location.location_document_content_fields:
-        class: '%ezpublish.search.solr.document_field_mapper.location.location_document_content_fields.class%'
-        arguments:
-            - '@ezpublish.spi.persistence.content_handler'
-            - '@ezpublish.spi.persistence.location_handler'
-            - '@ezpublish.spi.persistence.content_type_handler'
-            - '@ezpublish.spi.persistence.object_state_handler'
-            - '@ezpublish.spi.persistence.section_handler'
         tags:
             - {name: ezpublish.search.solr.document_field_mapper.location}

--- a/lib/ResultExtractor/LoadingResultExtractor.php
+++ b/lib/ResultExtractor/LoadingResultExtractor.php
@@ -59,11 +59,11 @@ class LoadingResultExtractor extends ResultExtractor
     public function extractHit($hit)
     {
         if ($hit->document_type_id === 'content') {
-            return $this->contentHandler->loadContentInfo($hit->content_id);
+            return $this->contentHandler->loadContentInfo($hit->content_id_id);
         }
 
         if ($hit->document_type_id === 'location') {
-            return $this->locationHandler->load($hit->location_id);
+            return $this->locationHandler->load($hit->location_id_id);
         }
 
         throw new RuntimeException(

--- a/lib/ResultExtractor/NativeResultExtractor.php
+++ b/lib/ResultExtractor/NativeResultExtractor.php
@@ -54,18 +54,18 @@ class NativeResultExtractor extends ResultExtractor
     {
         $contentInfo = new ContentInfo(
             array(
-                'id' => (int)$hit->content_id,
-                'name' => $hit->name_s,
-                'contentTypeId' => (int)$hit->type_id,
-                'sectionId' => (int)$hit->section_id,
-                'currentVersionNo' => $hit->version_no_i,
+                'id' => (int)$hit->content_id_id,
+                'name' => $hit->content_name_s,
+                'contentTypeId' => (int)$hit->content_type_id_id,
+                'sectionId' => (int)$hit->content_section_id_id,
+                'currentVersionNo' => $hit->content_version_no_i,
                 'isPublished' => true,
-                'ownerId' => (int)$hit->owner_id,
-                'modificationDate' => strtotime($hit->modified_dt),
-                'publicationDate' => strtotime($hit->published_dt),
-                'alwaysAvailable' => $hit->always_available_b,
-                'remoteId' => $hit->remote_id_id,
-                'mainLanguageCode' => $hit->main_language_code_s,
+                'ownerId' => (int)$hit->content_owner_user_id_id,
+                'modificationDate' => strtotime($hit->content_modification_date_dt),
+                'publicationDate' => strtotime($hit->content_publication_date_dt),
+                'alwaysAvailable' => $hit->content_always_available_b,
+                'remoteId' => $hit->content_remote_id_id,
+                'mainLanguageCode' => $hit->content_main_language_code_s,
             )
         );
 


### PR DESCRIPTION
This syncs field names for the same base Content fields between document field mappers and criteria visitors, enabling using same a field mapper for those fields.

`ContentDocumentBaseFields` and `LocationDocumentContentFields` are now replaces by single `BlockDocumentsBaseContentFields` document field mapper.

Follow up: move matching criteria and sort clauses to `Common` namespace and remove duplicates.
